### PR TITLE
Updates for OBC elementProperties

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
 <a style="width: fit-content;" href="./packages\webifc\src\components\tables\EntityAttributes\example.html">webifc/EntityAttributes</a>
 <a style="width: fit-content;" href="./packages\obc\src\components\tables\ModelsList\example.html">obc/ModelsList</a>
 <a style="width: fit-content;" href="./packages\obc\src\components\tables\EntityAttributes\example.html">obc/EntityAttributes</a>
+<a style="width: fit-content;" href="./packages\obc\src\components\tables\ElementProperties\example.html">obc/ElementProperties</a>
 <a style="width: fit-content;" href="./packages\obc\src\components\tables\ClassificationsTree\example.html">obc/ClassificationsTree</a>
 <a style="width: fit-content;" href="./packages\core\src\core\Component\example.html">core/Component</a>
 <a style="width: fit-content;" href="./packages\core\src\components\Toolbar\example.html">core/Toolbar</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1117,7 +1117,6 @@
       "resolved": "https://registry.npmjs.org/@thatopen/fragments/-/fragments-2.0.0-alpha.1.tgz",
       "integrity": "sha512-VQBKPtWJhqTOn0fZ8PBTN7yoyaRfGEsDTE37NYedAINQOKIavLHJJvpfbap70bjo+Tx/PdIkGXlwmno468WXnw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "flatbuffers": "23.3.3",
         "three-mesh-bvh": "0.7.0",
@@ -2708,8 +2707,7 @@
       "version": "23.3.3",
       "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-23.3.3.tgz",
       "integrity": "sha512-jmreOaAT1t55keaf+Z259Tvh8tR/Srry9K8dgCgvizhKSEr6gLGgaOJI2WFL5fkOpGOGRZwxUrlFn0GCmXUy6g==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/flatted": {
       "version": "3.3.1",
@@ -4846,7 +4844,6 @@
       "resolved": "https://registry.npmjs.org/unzipit/-/unzipit-1.4.3.tgz",
       "integrity": "sha512-gsq2PdJIWWGhx5kcdWStvNWit9FVdTewm4SEG7gFskWs+XCVaULt9+BwuoBtJiRE8eo3L1IPAOrbByNLtLtIlg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "uzip-module": "^1.0.2"
       },
@@ -4867,8 +4864,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/uzip-module/-/uzip-module-1.0.3.tgz",
       "integrity": "sha512-AMqwWZaknLM77G+VPYNZLEruMGWGzyigPK3/Whg99B3S6vGHuqsyl5ZrOv1UUF3paGK1U6PM0cnayioaryg/fA==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/validator": {
       "version": "13.11.0",
@@ -5209,6 +5205,7 @@
       },
       "devDependencies": {
         "@thatopen/components": "2.0.0-alpha.7",
+        "@thatopen/fragments": "2.0.0-alpha.1",
         "@types/three": "0.160.0",
         "lit": "3.1.2",
         "three": "0.160.1",

--- a/packages/core/src/components/Table/src/TableRow.ts
+++ b/packages/core/src/components/Table/src/TableRow.ts
@@ -121,22 +121,33 @@ export class TableRow extends Component {
       } else {
         content = html`<bim-label label="${value}"></bim-label>`;
       }
+
       const isFirstCell = this._columnNames.indexOf(column) === 0;
       const style = `
         ${isFirstCell && !this.isHeader ? "justify-content: normal" : ""};
         ${isFirstCell && !this.isHeader ? `margin-left: ${indentation + 0.125}rem` : ""}
       `;
+
       this._cells = [];
-      const getValue = (el: Element | undefined) => {
+      const onCellCreated = (el?: Element) => {
         if (!el) return;
         const cell = el as TableCell;
         this._cells.push(cell);
+        setTimeout(() => {
+          this.dispatchEvent(
+            new CustomEvent<{ cell: TableCell }>("cellcreated", {
+              detail: { cell },
+            }),
+          );
+        });
       };
+
       const cell = html`
-        <bim-table-cell ${ref(getValue)} style="${style}" .column=${column}
+        <bim-table-cell ${ref(onCellCreated)} style="${style}" .column=${column}
           >${content}</bim-table-cell
         >
       `;
+
       cells.push(cell);
     }
 

--- a/packages/obc/package.json
+++ b/packages/obc/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@thatopen/components": "2.0.0-alpha.7",
+    "@thatopen/fragments": "2.0.0-alpha.1",
     "@types/three": "0.160.0",
     "lit": "3.1.2",
     "three": "0.160.1",

--- a/packages/obc/src/components/tables/ElementProperties/example.ts
+++ b/packages/obc/src/components/tables/ElementProperties/example.ts
@@ -74,18 +74,13 @@ await indexer.process(model);
 
 const [propertiesTable] = CUI.tables.elementProperties({
   components,
-  model,
-  expressID: 141,
+  fragmentIdMap: model.getFragmentMap([183, 141]),
 });
 
 const propertiesPanel = BUI.Component.create(() => {
   return BUI.html`
   <bim-panel label="Properties">
     <bim-panel-section label="Element Data">
-      <bim-selector-input>
-        <bim-option label="Instance" checked></bim-option>
-        <bim-option label="Type"></bim-option>
-      </bim-selector-input> 
       ${propertiesTable}
     </bim-panel-section>
   </bim-panel>

--- a/packages/obc/src/components/tables/EntityAttributes/src/template.ts
+++ b/packages/obc/src/components/tables/EntityAttributes/src/template.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import * as FRAGS from "@thatopen/fragments";
 import * as BUI from "@thatopen/ui";
 import * as OBC from "@thatopen/components";
 
@@ -13,7 +15,7 @@ type AttributesToInclude =
 
 export interface EntityAttributesUIState {
   components: OBC.Components;
-  model: any;
+  model: FRAGS.FragmentsGroup;
   expressIDs: number[];
   editable?: boolean;
   attributeElements?: AttributeElements;
@@ -44,7 +46,7 @@ const defaultAttributes: Attributes[] = [
 
 async function processEntityAttributes(
   components: OBC.Components,
-  model: any,
+  model: FRAGS.FragmentsGroup,
   expressID: number,
   attributesToInclude = defaultAttributes,
   attributeElements: AttributeElements = {},
@@ -52,6 +54,17 @@ async function processEntityAttributes(
 ): Promise<BUI.TableGroupData> {
   const indexer = components.get(OBC.IfcRelationsIndexer);
   const attributes = await model.getProperties(expressID);
+  if (!attributes)
+    return {
+      data: { Entity: `${expressID} properties not found...` },
+      onRowCreated(row) {
+        row.addEventListener("cellcreated", (event) => {
+          if (!(event instanceof CustomEvent)) return;
+          const { cell } = event.detail;
+          cell.style.gridColumn = "1 / -1";
+        });
+      },
+    };
   const modelRelations = indexer.relationMaps[model.uuid];
 
   const entityRow: BUI.TableGroupData = {


### PR DESCRIPTION
### Description
This PR updates the `elementProperties` functional component from `obc` to accept a `FRAGS.FragmentIdMap` rather than a `model` and `expressID`.