### PR TITLE
feat(obc): show the material profile in ElementProperties component

### DIFF
--- a/packages/obc/src/components/tables/ElementProperties/src/materials-row.ts
+++ b/packages/obc/src/components/tables/ElementProperties/src/materials-row.ts
@@ -44,6 +44,39 @@ export const createMaterialsRow = async (
         row.children.push(layerRow);
       }
     }
+    if (material.type === WEBIFC.IFCMATERIALPROFILESETUSAGE) {
+      const profileSetID = material.ForProfileSet?.value;
+      const profileSetAttrs = await model.getProperties(profileSetID);
+      if (!profileSetAttrs) continue;
+      for (const profileHandle of profileSetAttrs.MaterialProfiles) {
+        const { value: profileID } = profileHandle;
+        const profileAttrs = await model.getProperties(profileID);
+        if (!profileAttrs) continue;
+        const materialAttrs = await model.getProperties(profileAttrs.Material?.value);
+        if (!materialAttrs) continue;
+        const profileRow = {
+          data: {
+            Name: "Profile",
+          },
+          children: [
+            {
+              data: {
+                Name: "Name",
+                Value: profileAttrs.Name?.value,
+              },
+            },
+            {
+              data: {
+                Name: "Material",
+                Value: materialAttrs.Name?.value,
+              },
+            },
+          ],
+        };
+        if (!row.children) row.children = [];
+        row.children.push(profileRow);
+      }
+    }
     if (material.type === WEBIFC.IFCMATERIALLIST) {
       for (const materialHandle of material.Materials) {
         const { value: materialID } = materialHandle;

--- a/packages/obc/src/components/tables/ElementProperties/src/template.ts
+++ b/packages/obc/src/components/tables/ElementProperties/src/template.ts
@@ -108,11 +108,12 @@ const processAssociateRelations = async (
         classifications.push(attrs);
       }
       if (
-        attrs.type === WEBIFC.IFCMATERIALLAYERSETUSAGE ||
-        attrs.type === WEBIFC.IFCMATERIALLAYERSET ||
-        attrs.type === WEBIFC.IFCMATERIALLAYER ||
-        attrs.type === WEBIFC.IFCMATERIAL ||
-        attrs.type === WEBIFC.IFCMATERIALLIST
+        [
+          WEBIFC.IFCMATERIALLAYERSETUSAGE,
+          WEBIFC.IFCMATERIAL,
+          WEBIFC.IFCMATERIALLIST,
+          WEBIFC.IFCMATERIALPROFILESETUSAGE,
+        ].includes(attrs.type)
       ) {
         materials.push(attrs);
       }


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

As a developer using thatopen/components, I want to display the IFCMATERIALPROFILE information within the ElementProperties component. Currently, this information is not extracted when fetching material properties from an IFC model.

This feature will ensure that profile data, including its name and associated material, is properly displayed in ElementProperties, improving the inspection of IFC elements.

### Additional context

#60 

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [x] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [x] Ideally, include relevant tests that fail without this PR but pass with it.
