### PR TITLE
fix: ViewCube example uses incorrect click event #76

### DIFF
--- a/packages/obc/src/core/ViewCube/example.ts
+++ b/packages/obc/src/core/ViewCube/example.ts
@@ -67,10 +67,6 @@ viewCube.camera = world.camera.three;
 viewport.append(viewCube);
 
 /* MD
-  This attaches the ViewCube to your viewport and links it to your camera's Three.js instance.
-*/
-
-/* MD
   ### 🔄 Keeping the ViewCube in Sync
 
   To keep the ViewCube orientation updated as the camera moves, listen for camera control updates:


### PR DESCRIPTION
<!-- Thanks you so much for your PR, your contribution is appreciated! ❤️ -->

### Description

<!-- Please insert your description here. Make sure to provide info about the "what" this PR is solving -->

### Additional context

This PR fixes #76 
- the ViewCube addEventListener was changed from "back" to "leftclick" to match the actual existing event and the doc description of this code block.
- an empty code block was removed (result of a duplicate description)

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following:

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Follow the [Conventional Commits v1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) standard for PR naming (e.g. `feat(examples): add hello-world example`).
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [X] Ideally, include relevant tests that fail without this PR but pass with it.
